### PR TITLE
bug fix

### DIFF
--- a/rvap/vap_main/vap_main.py
+++ b/rvap/vap_main/vap_main.py
@@ -264,6 +264,9 @@ class VAPRealTime():
                 x1_ = torch.from_numpy(x1).to(self.device).unsqueeze(0).unsqueeze(0)
                 x2_ = torch.from_numpy(x2).to(self.device).unsqueeze(0).unsqueeze(0)
 
+            x1_ = x1_.float()
+            x2_ = x2_.float()
+
             e1, e2 = self.vap.encode_audio(x1_, x2_)
             
             self.e1_context.append(e1)


### PR DESCRIPTION
While following the `How to use` section in the README, I encountered an error in step 2. When executing the main VAP program, the following error was displayed:

> [IN] Disconnected by ('127.0.0.1', 48888)
> [Errno 98] Address already in use

I have made modifications to address this issue.

